### PR TITLE
Add more details for Stack posts

### DIFF
--- a/convex/stack.ts
+++ b/convex/stack.ts
@@ -25,6 +25,8 @@ type AlgoliaStackDocument = {
   title: string;
   summary: string;
   mainImageUrl: string;
+  authorName: string;
+  authorImageUrl: string;
   content: string;
   tags: string[];
 };
@@ -37,6 +39,8 @@ const postFields = `
   content,
   summary,
   'mainImageUrl': mainImage.asset->url,
+  'authorName': author->name,
+  'authorImageUrl': author->image.asset->url,
   'slug':slug.current,
   'tags': tags[]->tag.current
 `;
@@ -47,6 +51,8 @@ type Post = {
   title: string;
   summary: string;
   mainImageUrl: string;
+  authorName: string;
+  authorImageUrl: string;
   content: string;
   tags: string[];
   slug: string;
@@ -72,6 +78,8 @@ function postToAlgoliaDocument(post: Post): AlgoliaStackDocument {
     title: post.title,
     summary: post.summary ?? "",
     mainImageUrl: post.mainImageUrl ?? "",
+    authorName: post.authorName,
+    authorImageUrl: post.authorImageUrl,
     content: markdownToTxt(post.content ?? ""),
     tags: post.tags,
   };

--- a/convex/stack.ts
+++ b/convex/stack.ts
@@ -24,6 +24,7 @@ type AlgoliaStackDocument = {
   type: 'article' | 'video';
   title: string;
   summary: string;
+  mainImageUrl: string;
   content: string;
   tags: string[];
 };
@@ -35,6 +36,7 @@ const postFields = `
   title,
   content,
   summary,
+  'mainImageUrl': mainImage.asset->url,
   'slug':slug.current,
   'tags': tags[]->tag.current
 `;
@@ -44,6 +46,7 @@ type Post = {
   type: 'article' | 'video';
   title: string;
   summary: string;
+  mainImageUrl: string;
   content: string;
   tags: string[];
   slug: string;
@@ -68,6 +71,7 @@ function postToAlgoliaDocument(post: Post): AlgoliaStackDocument {
     type: post.type,
     title: post.title,
     summary: post.summary ?? "",
+    mainImageUrl: post.mainImageUrl ?? "",
     content: markdownToTxt(post.content ?? ""),
     tags: post.tags,
   };

--- a/convex/stack.ts
+++ b/convex/stack.ts
@@ -21,6 +21,7 @@ const A_LOT_OF_POSTS = 10000;
 
 type AlgoliaStackDocument = {
   objectID: string;
+  type: 'article' | 'video';
   title: string;
   summary: string;
   content: string;
@@ -30,6 +31,7 @@ type AlgoliaStackDocument = {
 // A union of the fields needed for fetching articles and videos.
 const postFields = `
   _id,
+  type,
   title,
   content,
   summary,
@@ -39,6 +41,7 @@ const postFields = `
 
 type Post = {
   _id: any;
+  type: 'article' | 'video';
   title: string;
   summary: string;
   content: string;
@@ -62,6 +65,7 @@ async function getPosts(limit: number): Promise<AlgoliaStackDocument[]> {
 function postToAlgoliaDocument(post: Post): AlgoliaStackDocument {
   return {
     objectID: post.slug,
+    type: post.type,
     title: post.title,
     summary: post.summary ?? "",
     content: markdownToTxt(post.content ?? ""),


### PR DESCRIPTION
Updates the `postToAlgoliaDocument()` function for Stack to include 4 new properties:
- Type of post (article or video)
- Main image
- Author name
- Author image